### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,3 +107,5 @@ stages:
                   serviceConnection: ${{ deployment.service_connection }}
                   terraformInitSubscription: ${{ deployment.init_subscription }}
                   product: ${{ variables.product }}
+                  terraformEnvironmentVariables:
+                    AZDO_PERSONAL_ACCESS_TOKEN: $(AZDO_PERSONAL_ACCESS_TOKEN)


### PR DESCRIPTION
### Change description ###
Setting the AZDO_PERSONAL_ACCESS_TOKEN now it's been set to a secret var and not picked up automatically, like it used to be.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
