### PR TITLE
DTSPO-11394 - use role_definition_resource_id for custom roles 

### DIFF
--- a/modules/management-group-bootstrap/readers.tf
+++ b/modules/management-group-bootstrap/readers.tf
@@ -24,5 +24,5 @@ resource "azurerm_role_assignment" "custom_role_assignments_readers" {
 
   principal_id       = azuread_group.readers[each.value.group].object_id
   scope              = "/providers/Microsoft.Management/managementGroups/${each.value.group}"
-  role_definition_id = var.custom_roles[each.value.role].role_definition_id
+  role_definition_id = var.custom_roles[each.value.role].role_definition_resource_id
 }

--- a/modules/subscription/role_assignments.tf
+++ b/modules/subscription/role_assignments.tf
@@ -16,6 +16,6 @@ resource "azurerm_role_assignment" "local_role_assignments" {
 resource "azurerm_role_assignment" "local_custom_role_assignments" {
   for_each           = { for k, v in var.custom_roles : k => v if contains(keys(local.custom_role_assignments), k) }
   scope              = "/subscriptions/${azurerm_subscription.this.subscription_id}"
-  role_definition_id = each.value.role_definition_id
+  role_definition_id = each.value.role_definition_resource_id
   principal_id       = local.custom_role_assignments[each.key].principal_id
 }


### PR DESCRIPTION
I think the full resource id for the definition needs to be used, so trying that to fix the error below:

`Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequestFormat" Message="The request was incorrectly formatted.`