### PR TITLE
fix: add depends on to ensure subscriptions are added to a mgmt group…

### DIFF
--- a/modules/enterprise/custom_roles.tf
+++ b/modules/enterprise/custom_roles.tf
@@ -8,4 +8,13 @@ resource "azurerm_role_definition" "custom_role_definitions" {
   permissions {
     actions = each.value.actions
   }
+
+  depends_on = [
+    azurerm_management_group.level_1,
+    azurerm_management_group.level_2,
+    azurerm_management_group.level_3,
+    azurerm_management_group.level_4,
+    azurerm_management_group.level_5,
+    azurerm_management_group.level_6
+  ]
 }


### PR DESCRIPTION
… before trying to reference custom roles from the mgmt group

### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15481


### Change description ###
Fix issue when creating a brand new subscription terraform tries to create a role assignment for a custom role created at the management group level when the subscriptions are not part of the management group.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
