### PR TITLE
Updated application_object_id property has been replaced

### DIFF
--- a/modules/environments/azure_devops.tf
+++ b/modules/environments/azure_devops.tf
@@ -3,7 +3,7 @@ resource "azuredevops_serviceendpoint_azurerm" "endpoint" {
   project_id            = var.project_id
   service_endpoint_name = "OPS-APPROVAL-GATE-${upper(var.env)}-ENVS"
   credentials {
-    serviceprincipalid  = azuread_service_principal.sp.application_id
+    serviceprincipalid  = azuread_service_principal.sp.client_id
     serviceprincipalkey = azuread_application_password.token.value
   }
   azurerm_spn_tenantid = data.azurerm_client_config.current.tenant_id

--- a/modules/environments/service_principal.tf
+++ b/modules/environments/service_principal.tf
@@ -33,6 +33,7 @@ resource "azuread_application" "app" {
       id_token_issuance_enabled     = true
     }
   }
+  notes = var.notes
 }
 
 resource "azuread_application_password" "token" {
@@ -43,5 +44,5 @@ resource "azuread_application_password" "token" {
 }
 
 resource "azuread_service_principal" "sp" {
-  application_id = azuread_application.app.application_id
+  client_id = azuread_application.app.client_id
 }

--- a/modules/environments/service_principal.tf
+++ b/modules/environments/service_principal.tf
@@ -36,7 +36,7 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_application_password" "token" {
-  application_object_id = azuread_application.app.id
+  application_id = azuread_application.app.id
   rotate_when_changed = {
     rotation = time_rotating.one_year.id
   }

--- a/modules/environments/variables.tf
+++ b/modules/environments/variables.tf
@@ -21,3 +21,10 @@ variable "project_id" {
   # PlatformOperations project
   default = "c8947a39-47e3-4236-8bc8-51ff42dbda51"
 }
+
+variable "notes" {
+  type        = string
+  description = "User defined Notes for the service prinicipal"
+  default     = "This service principal created by hmcts/azure-enterprise repository"
+}
+

--- a/modules/environments/variables.tf
+++ b/modules/environments/variables.tf
@@ -24,7 +24,7 @@ variable "project_id" {
 
 variable "notes" {
   type        = string
-  description = "User defined Notes for the service prinicipal"
+  description = "User defined Notes for the service principal"
   default     = "This service principal created by hmcts/azure-enterprise repository"
 }
 

--- a/modules/subscription/acme.tf
+++ b/modules/subscription/acme.tf
@@ -33,4 +33,5 @@ resource "azuread_application" "acme_appreg" {
       type = "Scope"
     }
   }
+  notes = var.notes
 }

--- a/modules/subscription/azure_devops.tf
+++ b/modules/subscription/azure_devops.tf
@@ -2,7 +2,7 @@ resource "azuredevops_serviceendpoint_azurerm" "endpoint" {
   project_id            = var.project_id
   service_endpoint_name = azurerm_subscription.this.subscription_name
   credentials {
-    serviceprincipalid  = azuread_service_principal.sp.application_id
+    serviceprincipalid  = azuread_service_principal.sp.client_id
     serviceprincipalkey = azuread_application_password.token.value
   }
   azurerm_spn_tenantid      = data.azurerm_client_config.current.tenant_id

--- a/modules/subscription/keyvault.tf
+++ b/modules/subscription/keyvault.tf
@@ -80,7 +80,7 @@ resource "azurerm_key_vault_secret" "sp_object_id" {
 
 resource "azurerm_key_vault_secret" "sp_app_id" {
   name         = "sp-application-id"
-  value        = azuread_application.app.application_id
+  value        = azuread_application.app.client_id
   key_vault_id = azurerm_key_vault.kv.id
 }
 

--- a/modules/subscription/service_principal.tf
+++ b/modules/subscription/service_principal.tf
@@ -56,6 +56,8 @@ resource "azuread_application" "app" {
       id_token_issuance_enabled     = true
     }
   }
+
+  notes = var.notes
 }
 
 resource "azuread_application_password" "token" {
@@ -66,5 +68,5 @@ resource "azuread_application_password" "token" {
 }
 
 resource "azuread_service_principal" "sp" {
-  application_id = azuread_application.app.application_id
+  client_id = azuread_application.app.client_id
 }

--- a/modules/subscription/service_principal.tf
+++ b/modules/subscription/service_principal.tf
@@ -59,7 +59,7 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_application_password" "token" {
-  application_object_id = azuread_application.app.id
+  application_id = azuread_application.app.id
   rotate_when_changed = {
     rotation = time_rotating.rotation_period.id
   }

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -87,6 +87,6 @@ variable "additional_api_permissions" {
 }
 variable "notes" {
   type        = string
-  description = "User defined Notes for the service prinicipal"
+  description = "User defined Notes for the service principal"
   default     = "This service principal created by hmcts/azure-enterprise repository"
 }

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -85,3 +85,8 @@ variable "additional_api_permissions" {
   description = "Additional API permissions to be added to the application"
   default     = {}
 }
+variable "notes" {
+  type        = string
+  description = "User defined Notes for the service prinicipal"
+  default     = "This service principal created by hmcts/azure-enterprise repository"
+}


### PR DESCRIPTION
to fix this warning

 Warning: Argument is deprecated
│ 
│   with module.environment["ptlsbox"].azuread_application_password.token,
│   on ../../modules/environments/service_principal.tf line 39, in resource "azuread_application_password" "token":
│   39:   application_object_id = azuread_application.app.id
│ 
│ The `application_object_id` property has been replaced with the
│ `application_id` property and will be removed in version 3.0 of the AzureAD
│ provider
