### PR TITLE
Add Jenkins prod MI subscription readers

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -16,6 +16,7 @@ cft_non_production_subscriptions = {
     deploy_acme = true
     additional_readers = [
       "14b22215-46e6-48a9-8681-e8cefe66236a", # jenkins-aat-mi
+      "c860eaa0-74be-4731-8370-db94c5fdad81", # jenkins-prod-mi
     ]
   }
   DCD-CFTAPPS-ITHC = {
@@ -29,6 +30,9 @@ cft_non_production_subscriptions = {
   }
   DCD-CNP-DEV = {
     deploy_acme = true
+    additional_readers = [
+      "c860eaa0-74be-4731-8370-db94c5fdad81", # jenkins-prod-mi
+    ]
   }
   DCD-CNP-QA = {
     deploy_acme = true
@@ -56,6 +60,7 @@ cft_production_subscriptions = {
       "c822a60c-d948-46f2-a4ce-b1c7ecd33f2f", # DTS Bootstrap (sub:dcd-cftapps-stg)
       "98053eb3-8523-4c5a-96d3-c15532f87c19", # DTS Bootstrap (sub:dcd-cftapps-prod)
       "14b22215-46e6-48a9-8681-e8cefe66236a", # jenkins-aat-mi
+      "c860eaa0-74be-4731-8370-db94c5fdad81", # jenkins-prod-mi
     ]
   }
   DTS-CFTSBOX-INTSVC = {


### PR DESCRIPTION
### Jira link

Adhoc change for the jenkins env agent work.

### Change description
- Adds `jenkins-prod-mi` as an additional reader on `DCD-CFTAPPS-DEV`, `DCD-CNP-DEV`, and `DTS-CFTPTL-INTSVC` so production Jenkins agents can read preview/PTL/CNP network resources during Terraform plans.
- Fixes this [issue](https://build.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fccd-shared-infrastructure/detail/PR-219/4/pipeline/287/)

### Testing done

- Verified `jenkins-prod-mi` currently has no effective Reader access on `DCD-CFTAPPS-DEV` or `DTS-CFTPTL-INTSVC` using Azure CLI role assignment checks.
- Verified the existing DTS Readers groups for `DCD-CFTAPPS-DEV`, `DCD-CNP-DEV`, and `DTS-CFTPTL-INTSVC` already have subscription-level Reader role assignments.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change