### PR TITLE
granting perms to the daily check Service principal

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -242,6 +242,15 @@ platform_production_subscriptions = {
   DTS-MANAGEMENT-PROD-INTSVC = {
     environment = "prod"
     product     = "mgmt"
+    additional_api_permissions = {
+      # Granting audit permissions to the daily check service principal
+      # these need to be granted in the portal, i think that's consistent with what we already have
+      "00000003-0000-0000-c000-000000000000" = { # ms graph
+        "c74fd47d-ed3c-45c3-9a9e-b8676de685d2" = "Role" # EntitlementManagement.Read.All
+        "01e37dc9-c035-40bd-b438-b2879c4870a6" = "Role" # PrivilegedAccess.Read.AzureADGroup
+        "98830695-27a2-44f7-8c18-0c3ebc9698f6" = "Role" # GroupMember.Read.All
+      }
+    }
   }
   HMCTS-HUB-PROD-INTSVC = {
     environment = "prod"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -245,7 +245,7 @@ platform_production_subscriptions = {
     additional_api_permissions = {
       # Granting audit permissions to the daily check service principal
       # these need to be granted in the portal, i think that's consistent with what we already have
-      "00000003-0000-0000-c000-000000000000" = { # ms graph
+      "00000003-0000-0000-c000-000000000000" = {        # ms graph
         "c74fd47d-ed3c-45c3-9a9e-b8676de685d2" = "Role" # EntitlementManagement.Read.All
         "01e37dc9-c035-40bd-b438-b2879c4870a6" = "Role" # PrivilegedAccess.Read.AzureADGroup
         "98830695-27a2-44f7-8c18-0c3ebc9698f6" = "Role" # GroupMember.Read.All

--- a/modules/subscription/data.tf
+++ b/modules/subscription/data.tf
@@ -14,3 +14,6 @@ data "azuread_group" "dts_operations" {
 # for lookups
 data "azuread_application_published_app_ids" "well_known" {}
 
+data "azuread_service_principal" "graph_api_principal" {
+client_id = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
+}

--- a/modules/subscription/data.tf
+++ b/modules/subscription/data.tf
@@ -11,9 +11,3 @@ data "azuread_group" "aks_global_admin" {
 data "azuread_group" "dts_operations" {
   display_name = "DTS Operations (env:${var.environment})"
 }
-# for lookups
-data "azuread_application_published_app_ids" "well_known" {}
-
-data "azuread_service_principal" "graph_api_principal" {
-  client_id = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
-}

--- a/modules/subscription/data.tf
+++ b/modules/subscription/data.tf
@@ -15,5 +15,5 @@ data "azuread_group" "dts_operations" {
 data "azuread_application_published_app_ids" "well_known" {}
 
 data "azuread_service_principal" "graph_api_principal" {
-client_id = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
+  client_id = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
 }

--- a/modules/subscription/data.tf
+++ b/modules/subscription/data.tf
@@ -11,4 +11,6 @@ data "azuread_group" "aks_global_admin" {
 data "azuread_group" "dts_operations" {
   display_name = "DTS Operations (env:${var.environment})"
 }
+# for lookups
+data "azuread_application_published_app_ids" "well_known" {}
 

--- a/modules/subscription/outputs.tf
+++ b/modules/subscription/outputs.tf
@@ -1,3 +1,0 @@
-output "published_app_ids" {
-  value = data.azuread_application_published_app_ids.well_known.result
-}

--- a/modules/subscription/outputs.tf
+++ b/modules/subscription/outputs.tf
@@ -1,0 +1,3 @@
+output "published_app_ids" {
+  value = data.azuread_application_published_app_ids.well_known.result
+}

--- a/modules/subscription/service_principal.tf
+++ b/modules/subscription/service_principal.tf
@@ -72,6 +72,7 @@ resource "azuread_application_api_access" "privilege_management_graph_perm" {
   application_id = azuread_application.app.id
   api_client_id  = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
   role_ids = [
+    # these need to be granted in the portal, i think that's consistent with what we already have
     data.azuread_service_principal.app.app_role_ids["EntitlementManagement.Read.All"],
     data.azuread_service_principal.app.app_role_ids["PrivilegedAccess.Read.AzureADGroup"],
     data.azuread_service_principal.app.app_role_ids["GroupMember.Read.All"],

--- a/modules/subscription/service_principal.tf
+++ b/modules/subscription/service_principal.tf
@@ -57,8 +57,27 @@ resource "azuread_application" "app" {
     }
   }
 
+  lifecycle { # used to append an extra assignment in a separate block
+    ignore_changes = [
+      required_resource_access,
+    ]
+  }
+
   notes = var.notes
 }
+
+resource "azuread_application_api_access" "privilege_management_graph_perm" {
+  count = local.app_name == "DTS Bootstrap (sub:dts-management-prod-intsvc)" ? 1 : 0
+
+  application_id = azuread_application.app.id
+  api_client_id  = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
+  role_ids = [
+    data.azuread_service_principal.app.app_role_ids["EntitlementManagement.Read.All"],
+    data.azuread_service_principal.app.app_role_ids["PrivilegedAccess.Read.AzureADGroup"],
+    data.azuread_service_principal.app.app_role_ids["GroupMember.Read.All"],
+  ]
+}
+
 
 resource "azuread_application_password" "token" {
   application_id = azuread_application.app.id

--- a/modules/subscription/service_principal.tf
+++ b/modules/subscription/service_principal.tf
@@ -73,9 +73,9 @@ resource "azuread_application_api_access" "privilege_management_graph_perm" {
   api_client_id  = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
   role_ids = [
     # these need to be granted in the portal, i think that's consistent with what we already have
-    data.azuread_service_principal.app.app_role_ids["EntitlementManagement.Read.All"],
-    data.azuread_service_principal.app.app_role_ids["PrivilegedAccess.Read.AzureADGroup"],
-    data.azuread_service_principal.app.app_role_ids["GroupMember.Read.All"],
+    data.azuread_service_principal.graph_api_principal.app_role_ids["EntitlementManagement.Read.All"],
+    data.azuread_service_principal.graph_api_principal.app_role_ids["PrivilegedAccess.Read.AzureADGroup"],
+    data.azuread_service_principal.graph_api_principal.app_role_ids["GroupMember.Read.All"],
   ]
 }
 

--- a/modules/subscription/service_principal.tf
+++ b/modules/subscription/service_principal.tf
@@ -57,28 +57,8 @@ resource "azuread_application" "app" {
     }
   }
 
-  lifecycle { # used to append an extra assignment in a separate block
-    ignore_changes = [
-      required_resource_access,
-    ]
-  }
-
   notes = var.notes
 }
-
-resource "azuread_application_api_access" "privilege_management_graph_perm" {
-  count = local.app_name == "DTS Bootstrap (sub:dts-management-prod-intsvc)" ? 1 : 0
-
-  application_id = azuread_application.app.id
-  api_client_id  = data.azuread_application_published_app_ids.well_known.result["MicrosoftGraph"]
-  role_ids = [
-    # these need to be granted in the portal, i think that's consistent with what we already have
-    data.azuread_service_principal.graph_api_principal.app_role_ids["EntitlementManagement.Read.All"],
-    data.azuread_service_principal.graph_api_principal.app_role_ids["PrivilegedAccess.Read.AzureADGroup"],
-    data.azuread_service_principal.graph_api_principal.app_role_ids["GroupMember.Read.All"],
-  ]
-}
-
 
 resource "azuread_application_password" "token" {
   application_id = azuread_application.app.id


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-32682
adds

    data.azuread_service_principal.app.app_role_ids["EntitlementManagement.Read.All"],
    data.azuread_service_principal.app.app_role_ids["PrivilegedAccess.Read.AzureADGroup"],
    data.azuread_service_principal.app.app_role_ids["GroupMember.Read.All"],

to only
"DTS Bootstrap (sub:dts-management-prod-intsvc)
on a gate

for purposes of running the daily audit script 

will require permissions grant in the portal as well

