### PR TITLE
Set purge protection to enabled by default

### DIFF
--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -46,7 +46,7 @@ variable "access_type" {
 variable "purge_protection_enabled" {
   description = "Should we enable Purge Protection on the KeyVault."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "sku_name" {


### PR DESCRIPTION
### Change description

This has been enabled on the cft ptl kv but no others
We can allow it on just this keyvault but we mandate this setting on all key vaults now so we might as well enable it on all of these
These are long lived key vaults and secrets so I don't think this should cause an issue

<img width="1716" height="462" alt="image" src="https://github.com/user-attachments/assets/b9178882-703e-421e-90dc-094af6a39be5" />

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
