### PR TITLE
fix: adding additional readers jenkins ithc and perftest mi

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -32,6 +32,8 @@ cft_non_production_subscriptions = {
     deploy_acme = true
     additional_readers = [
       "c860eaa0-74be-4731-8370-db94c5fdad81", # jenkins-prod-mi
+      "22349922-a968-43b8-b5a5-1da0e57504c2", # jenkins-ithc-mi
+      "531d44e7-5fe6-40cb-a390-ae1f36a23878", # jenkins-perftest-mi
     ]
   }
   DCD-CNP-QA = {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33432

### Change description

Updated DCD-CNP-DEV additional_readers with:

jenkins-ithc-mi (22349922-xxxx
jenkins-perftest-mi (531d44e7-xxxxx
This should clear the ithc/perftest providers/read 403 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
