### PR TITLE
Revert "Uncomment sandbox subs"

### DIFF
--- a/environments/sandbox/sandbox.tfvars
+++ b/environments/sandbox/sandbox.tfvars
@@ -1,20 +1,20 @@
 cft_sandbox_subscriptions = {
-  DTS-RBAC-SANDBOX = {
-    environment = "sbox"
-  }
+  # DTS-RBAC-SANDBOX = {
+  #   environment = "sbox"
+  # }
 }
 
 cft_production_subscriptions = {
-  DTS-RBAC-PROD = {
-    environment = "prod"
-  }
-  DTS-RBAC-PRODUCTION = {
-    environment = "prod"
-  }
-  DCD-RBAC-CONTROL = {
-    environment      = "prod"
-    replication_type = "RAGRS"
-  }
+  # DTS-RBAC-PROD = {
+  #   environment = "prod"
+  # }
+  # DTS-RBAC-PRODUCTION = {
+  #   environment = "prod"
+  # }
+  # DCD-RBAC-CONTROL = {
+  #   environment      = "prod"
+  #   replication_type = "RAGRS"
+  # }
 }
 
 cft_non_production_subscriptions = {


### PR DESCRIPTION
Reverts hmcts/azure-enterprise#181

The error from before is still there. Reverting this for now so it can be fixed in the background.

Error:

```
 Error: creating new Subscription (Alias "DTS-RBAC-SANDBOX"): performing AliasCreate: subscriptions.SubscriptionsClient#AliasCreate: Failure sending request: StatusCode=0 -- Original Error: Code="Forbidden" Message="User is not authorized to access enrollment account '123456'. {\"error\":{\"code\":\"Forbidden\",\"message\":\"User is not authorized to access enrollment account '123456'.\"}}"
```